### PR TITLE
Fix SearchByJobNumber site dropdown opening behavior

### DIFF
--- a/SDSFinder/Pages/SearchByJobNumber.razor
+++ b/SDSFinder/Pages/SearchByJobNumber.razor
@@ -29,6 +29,7 @@
                                  Margin="@Margin.Dense"
                                  Dense="true"
                                  Variant="Variant.Filled"
+                                 MinCharacters="0"
                                  SearchFunc="GetSites"
                                  ToStringFunc="@(e => e is null || string.IsNullOrEmpty(e.SiteCode) || string.IsNullOrEmpty(e.SiteName) ? null : $"{e.SiteCode} - {e.SiteName}")"
                                  MaxItems="100"


### PR DESCRIPTION
## Summary
- ensure the site autocomplete fetches results immediately when focused by setting MinCharacters to 0

## Testing
- not run (environment lacks dotnet)


------
https://chatgpt.com/codex/tasks/task_b_68e37cbe3c688329b10dbf3aa6d230aa